### PR TITLE
Add private-chef as a package/runtime dep

### DIFF
--- a/config/projects/opscode-push-jobs-server.rb
+++ b/config/projects/opscode-push-jobs-server.rb
@@ -22,6 +22,7 @@ install_path    "/opt/opscode-push-jobs-server"
 build_version   Omnibus::BuildVersion.full
 build_iteration "1"
 
+runtime_dependencies [ "private-chef" ]
 deps = []
 
 # global


### PR DESCRIPTION
Depends on a version of omnibus-ruby that understands this.  Need to update Gemfile.lock to grab that once the PR on omnibus-ruby is accepted
