### PR TITLE
Pushy server looks up org_id from opscode-account

### DIFF
--- a/files/pushy-server-cookbooks/opscode-pushy-server/templates/default/opscode-pushy-server.config.erb
+++ b/files/pushy-server-cookbooks/opscode-pushy-server/templates/default/opscode-pushy-server.config.erb
@@ -87,6 +87,9 @@
           %% webmachine log dir
           {log_dir, "<%= @log_directory %>" },
 
+          %% Used for service to service calls
+          {erchef_root_url, "https://<%= node['fqdn'] %>"},
+
           %% Zeromq tunings
           {zmq_io_processes, <%= @zmq_io_processes %> }
          ]},


### PR DESCRIPTION
Lookup OrgId from OrgName by querying opscode-account
- pivotal is used for connections
- Uses chef_authn for signing of request
- Client passes correct orgname across in Zeromq messages
- Added tests for pushy_org
- app.config now sets erchef_root_url to specify service to contact
  for service to service calls
