### PR TITLE
Added more metadata to log output

### DIFF
--- a/files/pushy-server-cookbooks/opscode-pushy-server/templates/default/opscode-pushy-server.config.erb
+++ b/files/pushy-server-cookbooks/opscode-pushy-server/templates/default/opscode-pushy-server.config.erb
@@ -22,7 +22,8 @@
             %% and the rotation time to "", or instead specify a 2-tuple that only
             %% consists of {Logfile, Level}.
             {handlers, [
-                {lager_console_backend, [info, {lager_default_formatter, [time," [",severity,"] ", pid, " ",  message, "\n"]}]},
+                {lager_console_backend, [info, {lager_default_formatter,
+                                                [time," [",severity,"] (", module, ":", line, ") ", pid, " ",  message, "\n"]}]},
                 {lager_file_backend, [
                     {"<%= File.join(@log_directory, 'error.log') %>", error, 10485760, "$D0", 5},
                     {"<%= File.join(@log_directory, 'console.log') %>", info, 10485760, "$D0", 5}


### PR DESCRIPTION
Pushy logging now captures module and line number, if available.
