### PR TITLE
Cleanup pushy config

### DIFF
--- a/files/pushy-server-cookbooks/opscode-pushy-server/attributes/default.rb
+++ b/files/pushy-server-cookbooks/opscode-pushy-server/attributes/default.rb
@@ -44,7 +44,6 @@ default['pushy']['opscode-pushy-server']['listen'] = '127.0.0.1'
 default['pushy']['opscode-pushy-server']['db_pool_size'] = '20'
 
 default['pushy']['opscode-pushy-server']['heartbeat_interval'] = '1000'
-default['pushy']['opscode-pushy-server']['dead_interval'] = '3'
 
 default['pushy']['opscode-pushy-server']['zeromq_listen_address'] = 'tcp://*'
 default['pushy']['opscode-pushy-server']['zmq_io_processes'] = '1'
@@ -54,7 +53,8 @@ default['pushy']['opscode-pushy-server']['command_port'] = '10002'
 default['pushy']['opscode-pushy-server']['api_port'] = '10003'
 default['pushy']['opscode-pushy-server']['down_threshold'] = '0.6'
 default['pushy']['opscode-pushy-server']['decay_window'] = '4'
-default['pushy']['opscode-pushy-server']['detect_offline_nodes_interval'] = '1000'
+default['pushy']['opscode-pushy-server']['detect_offline_nodes_interval'] = '4'
+default['pushy']['opscode-pushy-server']['enable_graphite'] = false
 default['pushy']['opscode-pushy-server']['keyring_dir'] = '/etc/opscode-push-jobs-server'
 
 ###

--- a/files/pushy-server-cookbooks/opscode-pushy-server/templates/default/opscode-pushy-server.config.erb
+++ b/files/pushy-server-cookbooks/opscode-pushy-server/templates/default/opscode-pushy-server.config.erb
@@ -77,7 +77,6 @@
  {pushy, [
           {server_name, "<%= node['fqdn'] %>" },
           {heartbeat_interval, <%= @heartbeat_interval %> },
-          {dead_interval, <%= @dead_interval %> },
           {zeromq_listen_address, "<%= @zeromq_listen_address %>" },
           {server_heartbeat_port, <%= @server_heartbeat_port %> },
           {command_port, <%= @command_port %> },
@@ -96,7 +95,7 @@
          ]},
          {pushy_common,[
                         {metrics_module, folsom_metrics},
-                        {enable_graphite, false}
+                        {enable_graphite, <%= @enable_graphite %> }
                        ]},
  {folsom_graphite,[ {application, "pushy"}]},
    {chef_authn,  [{keyring_dir, "<%= @keyring_dir %>"},


### PR DESCRIPTION
Config cleanup
- Remove dead items from pushy server config
- Add enable_graphite tunable
- make offline_nodes tunable be expressed as multiple of heartbeats
