### PR TITLE
opscode-pushy-server service fails to restart

### DIFF
--- a/files/pushy-server-cookbooks/runit/definitions/runit_service.rb
+++ b/files/pushy-server-cookbooks/runit/definitions/runit_service.rb
@@ -158,6 +158,17 @@ define :runit_service, :directory => nil, :only_if => false, :finish_script => f
       end
     end
 
+    if params[:options].respond_to?(:has_key?) && params[:options][:log_directory]
+      template "#{params[:options][:log_directory]}/config" do
+        cookbook "runit"
+        source "config.svlogd"
+        mode "0644"
+        owner "root"
+        group "root"
+        variables :options => params[:options]
+      end
+    end
+
     ruby_block "supervise_#{params[:name]}_sleep" do
       block do
         Chef::Log.debug("Waiting until named pipe #{sv_dir_name}/supervise/ok exists.")
@@ -171,7 +182,7 @@ define :runit_service, :directory => nil, :only_if => false, :finish_script => f
       if params[:owner]
         control_cmd = "#{node[:runit][:chpst_bin]} -u #{params[:owner]} #{control_cmd}"
       end
-      provider Chef::Provider::Service::Init
+      provider Chef::Provider::Service::Simple
       supports :restart => true, :status => true
       start_command "#{control_cmd} #{params[:start_command]} #{service_dir_name}"
       stop_command "#{control_cmd} #{params[:stop_command]} #{service_dir_name}"

--- a/files/pushy-server-cookbooks/runit/templates/default/config.svlogd
+++ b/files/pushy-server-cookbooks/runit/templates/default/config.svlogd
@@ -1,0 +1,3 @@
+# svlogd configuration
+S<%= @options[:svlogd_size] %>
+n<%= @options[:svlogd_num] %>


### PR DESCRIPTION
This fixes an error on a restart triggered by changes in config file
not running due to a problem in runit cookbook making it look for init file
in /etc/init.d

This commit containts the changes between omnibus-pushy and opscode-omnibus
runit cookbook
