### PR TITLE
Nginx config as an addon

### DIFF
--- a/files/pushy-server-cookbooks/opscode-pushy-server/attributes/default.rb
+++ b/files/pushy-server-cookbooks/opscode-pushy-server/attributes/default.rb
@@ -51,6 +51,7 @@ default['pushy']['opscode-pushy-server']['heartbeat_interval'] = '1000'
 default['pushy']['opscode-pushy-server']['zeromq_listen_address'] = 'tcp://*'
 default['pushy']['opscode-pushy-server']['zmq_io_processes'] = '1'
 
+default['pushy']['opscode-pushy-server']['vip'] = '127.0.0.1'
 default['pushy']['opscode-pushy-server']['server_heartbeat_port'] = '10000'
 default['pushy']['opscode-pushy-server']['command_port'] = '10002'
 default['pushy']['opscode-pushy-server']['api_port'] = '10003'
@@ -73,3 +74,5 @@ default['pushy']['postgresql']['sql_ro_user'] = "opscode_pushy_ro"
 default['pushy']['postgresql']['sql_ro_password'] = "shmunzeltazzen"
 default['pushy']['postgresql']['vip'] = "127.0.0.1"
 default['pushy']['postgresql']['port'] = 5432
+
+default['pushy']['nginx']['dir'] = "/var/opt/opscode/nginx"

--- a/files/pushy-server-cookbooks/opscode-pushy-server/libraries/helper.rb
+++ b/files/pushy-server-cookbooks/opscode-pushy-server/libraries/helper.rb
@@ -18,12 +18,16 @@
 require 'chef/shell_out'
 
 class OmnibusHelper
-  def self.should_notify?(service_name)
-    File.symlink?("/opt/opscode-push-jobs-server/service/#{service_name}") && check_status(service_name)
+  def self.should_notify?(service_name,
+                          path = "/opt/opscode-push-jobs-server",
+                          command = "opscode-push-jobs-server-ctl")
+    File.symlink?("#{path}/service/#{service_name}") && check_status(service_name, path, command)
   end
 
-  def self.check_status(service_name)
-    o = Chef::ShellOut.new("/opt/opscode-push-jobs-server/bin/opscode-push-jobs-server-ctl status #{service_name}")
+  def self.check_status(service_name,
+                        path="/opt/opscode-push-jobs-server",
+                        command="opscode-push-jobs-server-ctl")
+    o = Chef::ShellOut.new("#{path}/bin/#{command} status #{service_name}")
     o.run_command
     o.exitstatus == 0 ? true : false
   end

--- a/files/pushy-server-cookbooks/opscode-pushy-server/recipes/default.rb
+++ b/files/pushy-server-cookbooks/opscode-pushy-server/recipes/default.rb
@@ -67,6 +67,7 @@ end
 include_recipe "runit"
 
 include_recipe "opscode-pushy-server::postgresql"
+include_recipe "opscode-pushy-server::nginx"
 
 # Configure Services
 [

--- a/files/pushy-server-cookbooks/opscode-pushy-server/recipes/nginx.rb
+++ b/files/pushy-server-cookbooks/opscode-pushy-server/recipes/nginx.rb
@@ -1,0 +1,33 @@
+#
+# Author:: James Casey (<james@opscode.com>)
+# Copyright:: Copyright (c) 2013 Opscode, Inc.
+#
+# All Rights Reserved
+#
+
+nginx_dir = node['pushy']['nginx']['dir']
+nginx_etc_dir = File.join(nginx_dir, "etc")
+nginx_addon_dir = File.join(nginx_etc_dir, "addon.d")
+
+# Pushy LB configs
+["upstreams", "external"].each do |config|
+  file = File.join(nginx_addon_dir, "10-push_jobs_#{config}.conf")
+
+  template file do
+    source "nginx-#{config}.conf.erb"
+    owner "root"
+    group "root"
+    mode "0644"
+    notifies :restart, 'service[nginx]' if OmnibusHelper.should_notify?("nginx",
+                                                                        node['pushy']['chef_base_path'],
+                                                                        "private-chef-ctl")
+  end
+end
+
+service "nginx" do
+    control_cmd = "#{node['pushy']['chef_base_path']}/embedded/bin/sv"
+    provider Chef::Provider::Service::Simple
+    supports :restart => true, :status => true
+    restart_command "#{control_cmd} restart nginx"
+    action :nothing
+end

--- a/files/pushy-server-cookbooks/opscode-pushy-server/recipes/opscode-pushy-server.rb
+++ b/files/pushy-server-cookbooks/opscode-pushy-server/recipes/opscode-pushy-server.rb
@@ -71,3 +71,5 @@ if node['pushy']['bootstrap']['enable']
     retries 20
   end
 end
+
+

--- a/files/pushy-server-cookbooks/opscode-pushy-server/templates/default/nginx-external.conf.erb
+++ b/files/pushy-server-cookbooks/opscode-pushy-server/templates/default/nginx-external.conf.erb
@@ -1,0 +1,16 @@
+#
+# Pushy endpoints in LB
+#
+
+# pushy status endpoint
+location ~ "^/pushy/_status/?$" {
+    types { }
+    default_type application/json;
+    proxy_pass http://opscode_pushy;
+}
+
+# We don't support web-ui for pushy API
+location ~ "^/organizations/[a-z0-9-_]+?/pushy/{0,1}" {
+    proxy_redirect http://opscode_pushy /;
+    proxy_pass http://opscode_pushy;
+}

--- a/files/pushy-server-cookbooks/opscode-pushy-server/templates/default/nginx-upstreams.conf.erb
+++ b/files/pushy-server-cookbooks/opscode-pushy-server/templates/default/nginx-upstreams.conf.erb
@@ -1,0 +1,6 @@
+#
+# Pushy upstream definition
+#
+upstream opscode_pushy {
+    server <%= node['pushy']['opscode-pushy-server']['vip'] %>:<%= node['pushy']['opscode-pushy-server']['api_port'] %>;
+}


### PR DESCRIPTION
Create separate upstream and endpoint config files for pushy

some jumping through hoops is needed to be able to restart the OPC nginx but this seems to be the cleanest and simplest patch that works
