### PR TITLE
Fix build break due to net-ssh: update chef gem to 11.2.0 from 10.16.4

### DIFF
--- a/config/software/chef-gem.rb
+++ b/config/software/chef-gem.rb
@@ -22,7 +22,7 @@
 # are tracked differently.
 
 name "chef-gem"
-version "10.16.4"
+version "11.2.0"
 
 dependencies ["ruby", "rubygems", "yajl"]
 


### PR DESCRIPTION
See feedback from original pull request: 
https://github.com/opscode/omnibus-pushy/pull/20

Build logs show the following break in net-ssh below -- upgrading to a version of the chef gem 11.2 or greater addresses net-ssh and was also done for the windows configuration of this build. Without this fix ci runs will continue to show this error.

Error output from Jenkins:

Expected process to exit with [0], but received '1'
---- Begin output of /opt/opscode-push-jobs-client/embedded/bin/gem install chef -v 10.16.4 -n /opt/opscode-push-jobs-client/bin --no-rdoc --no-ri ----
STDOUT: 
STDERR: ERROR: While executing gem ... (Gem::DependencyError)
Unable to resolve dependencies: chef requires net-ssh (~> 2.2.2); net-ssh-multi requires net-ssh (>= 2.1.4); net-ssh-gateway requires net-ssh (>= 2.6.5)
---- End output of /opt/opscode-push-jobs-client/embedded/bin/gem install chef -v 10.16.4 -n /opt/opscode-push-jobs-client/bin --no-rdoc --no-ri ----
Ran /opt/opscode-push-jobs-client/embedded/bin/gem install chef -v 10.16.4 -n /opt/opscode-push-jobs-client/bin --no-rdoc --no-ri returned 1
