### PR TITLE
Pick up fixes for windows build boxes installing Ruby

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/opscode/omnibus-ruby.git
-  revision: b6dc3065bbdd119015492d5570167ea133d1f6fd
+  revision: b59263f903f0df8f521e6e4cfe1c77241ce102d2
   branch: master
   specs:
     omnibus (0.5.3)


### PR DESCRIPTION
Omnibus-ruby was updated with a cookbook change to stop passing a parameter to the Windows Ruby installer that was causing the installer to fail. This bug breaks new Windows build boxes and requires a manual workaround. The change is to update the Gem file for Pushy to pick up the cookbook fix.
