### PR TITLE
Omnibus-ruby update for windows cookbook fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/opscode/omnibus-ruby.git
-  revision: ae0ba97de4af904c68f4ccb9c3a4db16abbd0533
+  revision: c48895d7810fcea5beea274428417d1934fafc76
   branch: master
   specs:
     omnibus (0.5.3)


### PR DESCRIPTION
The Ruby_1.9 cookbook of omnibus-ruby has a bug that requires manual workarounds when installing new Windows build computers -- this change is to pick up that fix from omnibus-ruby. See https://github.com/opscode/omnibus-ruby/pull/33.
