### PR TITLE
Add template for vm.args

### DIFF
--- a/files/pushy-server-cookbooks/opscode-pushy-server/recipes/opscode-pushy-server.rb
+++ b/files/pushy-server-cookbooks/opscode-pushy-server/recipes/opscode-pushy-server.rb
@@ -45,7 +45,8 @@ template "#{node['pushy']['install_path']}/embedded/service/opscode-pushy-server
   notifies :restart, 'runit_service[opscode-pushy-server]' if is_data_master?
 end
 
-pushy_config = File.join(pushy_etc_dir, "app.config")
+pushy_config  = File.join(pushy_etc_dir, "app.config")
+pushy_vm_args = File.join(pushy_etc_dir, "vm.args")
 
 template pushy_config do
   source "opscode-pushy-server.config.erb"
@@ -54,8 +55,18 @@ template pushy_config do
   notifies :restart, 'runit_service[opscode-pushy-server]' if is_data_master?
 end
 
+template pushy_vm_args do
+  source "vm.args.erb"
+  mode "644"
+  notifies :restart, 'runit_service[opscode-pushy-server]' if is_data_master?
+end
+
 link "#{node['pushy']['install_path']}/embedded/service/opscode-pushy-server/etc/app.config" do
   to pushy_config
+end
+
+link "#{node['pushy']['install_path']}/embedded/service/opscode-pushy-server/etc/vm.args" do
+  to pushy_vm_args
 end
 
 component_runit_service "opscode-pushy-server" do

--- a/files/pushy-server-cookbooks/opscode-pushy-server/templates/default/vm.args.erb
+++ b/files/pushy-server-cookbooks/opscode-pushy-server/templates/default/vm.args.erb
@@ -1,0 +1,33 @@
+## Name of the node
+-name pushy@127.0.0.1
+
+## Cookie for distributed erlang
+-setcookie pushy
+
+## Heartbeat management; auto-restarts VM if it dies or becomes unresponsive
+## (Disabled by default..use with caution!)
+##-heart
+
+## Enable kernel poll and a few async threads
++K true
++A 10
+
++P 262144
+
+-smp enable
+<% if node['cpu']['total'] == 1 %>
+# Pushy only works properly with multiple schedulers.  If we're
+# running on a single core machine, we need start up at least 2.
+# If we're on a multicore machine, we'll just let the Erlang VM sort
+# things out.
++S 2:2
+<% end %>
+
+## Increase number of concurrent ports/sockets
+-env ERL_MAX_PORTS 65536
+
+## Tweak GC to run more often
+-env ERL_FULLSWEEP_AFTER 10
+
+## Increase logfile size to 10M
+-env RUN_ERL_LOG_MAXSIZE 10000000


### PR DESCRIPTION
We need to start up multiple schedulers on single core machines for
Pushy to work properly.
