### PR TITLE
workaround for OpenSSL `make -j` issues

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/opscode/omnibus-software.git
-  revision: ade8df6f4c722b6bcc609a68c953684236c1c6c2
+  revision: 42d0a22686dcbc81b96f8bc2e544e706c7426121
   branch: master
   specs:
     omnibus-software (0.0.1)


### PR DESCRIPTION
TL;DR - OpenSSL hates `make -j`

Smoke test build passed:
http://andra.ci.opscode.us/job/opscode-push-jobs-server-trigger-ad-hoc/19/downstreambuildview/?

/cc @jamesc @christophermaier @jkeiser 
