### PR TITLE
Ensure that Pushy works properly on tiered deploys

### DIFF
--- a/files/pushy-server-cookbooks/opscode-pushy-server/libraries/pushy_server.rb
+++ b/files/pushy-server-cookbooks/opscode-pushy-server/libraries/pushy_server.rb
@@ -85,9 +85,10 @@ module PushJobsServer
 
     def generate_config(node_name)
       generate_secrets(node_name)
-      case node['private_chef']['topology']
-      when "ha"
-        PushJobsServer['opscode_pushy_server']['ha'] = true
+      topology = node['private_chef']['topology']
+      case topology
+      when "ha", "tier"
+        PushJobsServer['opscode_pushy_server']['ha'] = (topology == 'ha')
         PushJobsServer['opscode_pushy_server']['vip'] = node['private_chef']['backend_vips']['ipaddress']
         PushJobsServer['postgresql']['vip']           = node['private_chef']['backend_vips']['ipaddress']
         case node['private_chef']['servers'][node_name]['role']


### PR DESCRIPTION
For Pushy's purposes, a tiered deploy is basically identical to an HA
deploy.  Prior to this fix, though, a tiered deploy ended up being
effectively a collection of standalone deploys, which doesn't work at
all.

Verified manually on a  tiered cluster in our testing environment.
