### PR TITLE
Add a changelog, with info for the 1.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.1.0 - 2014-02-11
+# 1.1.0 - 2014-02-12
 
 - Add X-Chef-Version HTTP header information for compatibility with EC
   11.1.0
@@ -10,6 +10,9 @@
 - Integration tests made more robust to timing issues
 
 # 1.0.3 - 2014-02-11
+
+Unpublished, following extended discussions on what our release
+support policy should be.
 
 Security release for a `libyaml` vulnerability.  Not compatible with
 Enterprise Chef 11.1.0; users that are upgrading their Enterprise Chef


### PR DESCRIPTION
Using this as a commit to base a new 1.1.0 tag on top of the now-ignored 1.0.2

cc: @seth @schisamo @sdelano 
