### PR TITLE
Wait a little longer before running Pedant test

### DIFF
--- a/jenkins/server-test.sh
+++ b/jenkins/server-test.sh
@@ -59,7 +59,7 @@ export PATH=/opt/opscode/bin:/opt/opscode/embedded/bin:$PATH
 sudo "private-chef-ctl" reconfigure
 sleep 120
 sudo "${project_name}-ctl" reconfigure
-sleep 10
+sleep 20
 sudo "${project_name}-ctl" test --all -J $WORKSPACE/pedant.xml --client-debug
 
 # when build succeeds, nuke the packages


### PR DESCRIPTION
This is specifically in response to
http://andra.ci.opscode.us/job/opscode-push-jobs-server-test/build_os=ubuntu-11.04,machine_architecture=x86_64,project=opscode-push-jobs-server,role=tester/253/,
where we get 503's for the org-creator.  We just need to give a little
more time for it to come up and create an org.

(We've seen this before; it's not just this one failure that is
prompting this change.)

cc: @schisamo @jkeiser @doubt72 @seth
