### PR TITLE
remove replaces line

### DIFF
--- a/config/projects/opscode-push-jobs-server.rb
+++ b/config/projects/opscode-push-jobs-server.rb
@@ -19,7 +19,6 @@ name       "opscode-push-jobs-server"
 maintainer "Opscode, Inc."
 homepage   "http://www.opscode.com"
 
-replaces        "opscode-push-jobs-server"
 install_path    "/opt/opscode-push-jobs-server"
 build_version   Omnibus::BuildVersion.new.semver
 build_iteration 1


### PR DESCRIPTION
completely unnecessary.

chef-client uses this because we changed the name of the RPM from
"chef-full" to "chef" back in history.  replacing the package you
are trying to install is wrong and confuses RPM and hurts upgrades.