### PR TITLE
Set correct maintainer and homepage.

### DIFF
--- a/config/projects/opscode-push-jobs-client-windows.rb
+++ b/config/projects/opscode-push-jobs-client-windows.rb
@@ -16,8 +16,8 @@
 #
 
 name       "opscode-push-jobs-client-windows"
-maintainer "Opscode, Inc."
-homepage   "http://www.opscode.com"
+maintainer "Chef Software, Inc."
+homepage   "http://www.getchef.com"
 
 package_name    "opscode-push-jobs-client"
 install_path    "c:\\opscode_pushy_build"

--- a/config/projects/opscode-push-jobs-client.rb
+++ b/config/projects/opscode-push-jobs-client.rb
@@ -16,8 +16,8 @@
 #
 
 name       "opscode-push-jobs-client"
-maintainer "Opscode, Inc."
-homepage   "http://www.opscode.com"
+maintainer "Chef Software, Inc."
+homepage   "http://www.getchef.com"
 
 install_path    "/opt/opscode-push-jobs-client"
 build_version   Omnibus::BuildVersion.new.semver

--- a/config/projects/opscode-push-jobs-server.rb
+++ b/config/projects/opscode-push-jobs-server.rb
@@ -16,8 +16,8 @@
 #
 
 name       "opscode-push-jobs-server"
-maintainer "Opscode, Inc."
-homepage   "http://www.opscode.com"
+maintainer "Chef Software, Inc."
+homepage   "http://www.getchef.com"
 
 replaces        "opscode-push-jobs-server"
 install_path    "/opt/opscode-push-jobs-server"


### PR DESCRIPTION
This data is important when publishing to Artifactory as it’s used in 
the underlying package path in the repo (e.g. `com/getchef`).

/cc @opscode/release-engineers @opscode/server-team @manderson26 

We'll probably need to backport this change to all stable branches also.
