### PR TITLE
remove runtime_dependency on private-chef

### DIFF
--- a/config/projects/opscode-push-jobs-server.rb
+++ b/config/projects/opscode-push-jobs-server.rb
@@ -26,8 +26,6 @@ build_iteration 1
 
 override :berkshelf, version: "v2.0.15"
 
-runtime_dependency "private-chef"
-
 # creates required build directories
 dependency "preparation"
 


### PR DESCRIPTION
To accommodate chef server 12.
