### PR TITLE
Server package dependency is incorrect, use Chef Server

### DIFF
--- a/config/projects/opscode-push-jobs-server.rb
+++ b/config/projects/opscode-push-jobs-server.rb
@@ -26,7 +26,7 @@ build_iteration 1
 
 override :berkshelf, version: "v2.0.15"
 
-runtime_dependency "private-chef"
+runtime_dependency "chef-server-core"
 
 # creates required build directories
 dependency "preparation"


### PR DESCRIPTION
```
Recipe: private-chef::add_ons_remote
  * package[opscode-push-jobs-server] action install
================================================================================
Error executing action `install` on resource 'package[opscode-push-jobs-server]'
================================================================================


Mixlib::ShellOut::ShellCommandFailed
------------------------------------
Expected process to exit with [0], but received '100'
---- Begin output of apt-get -q -y install opscode-push-jobs-server=1.1.2-1 ----
STDOUT: Reading package lists...
Building dependency tree...
Reading state information...
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 opscode-push-jobs-server : Depends: private-chef but it is not installable
STDERR: E: Unable to correct problems, you have held broken packages.
---- End output of apt-get -q -y install opscode-push-jobs-server=1.1.2-1 ----
Ran apt-get -q -y install opscode-push-jobs-server=1.1.2-1 returned 100
```
