### PR TITLE
Point to ffi 1.9.5.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,7 +21,7 @@ GEM
   specs:
     chef-sugar (2.3.0)
     cleanroom (1.0.0)
-    ffi (1.9.4)
+    ffi (1.9.5)
     ffi-yajl (1.1.0)
       ffi (~> 1.5)
       libyajl2 (~> 1.0)


### PR DESCRIPTION
ffi 1.9.4 pulled due to https://github.com/ffi/ffi/issues/371.
