### PR TITLE
Remove replace line config/projects/opscode-push-jobs-server.rb as it is harmful

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Push Jobs Server Changelog
 
+## Next
+* Remove replaces line for RPM build 
+
 ## 1.1.6 (2014-12-04)
 * Sign packages with Omnibus 4
 * Update mixlib-shellout to 1.6.1

--- a/config/projects/opscode-push-jobs-server.rb
+++ b/config/projects/opscode-push-jobs-server.rb
@@ -18,7 +18,6 @@ name       "opscode-push-jobs-server"
 maintainer "Chef Software, Inc."
 homepage   "http://www.getchef.com"
 
-replace         "opscode-push-jobs-server"
 install_dir    "/opt/opscode-push-jobs-server"
 build_version   Omnibus::BuildVersion.new.semver
 build_iteration 1


### PR DESCRIPTION
Rework of https://github.com/chef/omnibus-pushy/pull/55:

This line is completely unnecessary.

chef-client uses this because we changed the name of the RPM from
"chef-full" to "chef" back in history. replacing the package you
are trying to install is wrong and confuses RPM and hurts upgrades.