### PR TITLE
update to 0.5.1 of enterprise-chef-common cookbooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Next
 * Remove replaces line for RPM build 
 
+* Update enterprise-chef-common to 0.5.1 (from 0.3.0)
+  Includes many HA improvments and refactoring for reusability, along
+  with updates for systemd and runit
+
 ## 1.1.6 (2014-12-04)
 * Sign packages with Omnibus 4
 * Update mixlib-shellout to 1.6.1

--- a/files/pushy-server-cookbooks/opscode-pushy-server/Berksfile
+++ b/files/pushy-server-cookbooks/opscode-pushy-server/Berksfile
@@ -1,4 +1,4 @@
 
 metadata
 
-cookbook 'enterprise', :git => 'git@github.com:opscode-cookbooks/enterprise-chef-common.git', :tag => '0.3.0'
+cookbook 'enterprise', :git => 'git@github.com:opscode-cookbooks/enterprise-chef-common.git', :tag => '0.5.1'


### PR DESCRIPTION
Bump enterprise-chef-common cookbooks so we don't slip too far behind.
