### PR TITLE
Add attribute to allow client visible server name to be set separately from the VIP

### DIFF
--- a/files/pushy-server-cookbooks/opscode-pushy-server/attributes/default.rb
+++ b/files/pushy-server-cookbooks/opscode-pushy-server/attributes/default.rb
@@ -45,6 +45,10 @@ default['pushy']['opscode-pushy-server']['heartbeat_interval'] = '1000'
 default['pushy']['opscode-pushy-server']['zeromq_listen_address'] = 'tcp://*'
 default['pushy']['opscode-pushy-server']['zmq_io_processes'] = '1'
 
+# server_name_advertised is the name the push server provides to clients to use for zeromq connections, and
+# must be and address clients can reach. This server may lie on the back end, so in HA configurations it will
+# eventually need to route to the backend VIP.  nil defaults to using node['pushy']['opscode-pushy-server']['vip']
+default['pushy']['opscode-pushy-server']['server_name_advertised'] = nil
 default['pushy']['opscode-pushy-server']['vip'] = '127.0.0.1'
 default['pushy']['opscode-pushy-server']['server_heartbeat_port'] = '10000'
 default['pushy']['opscode-pushy-server']['command_port'] = '10002'

--- a/files/pushy-server-cookbooks/opscode-pushy-server/recipes/opscode-pushy-server.rb
+++ b/files/pushy-server-cookbooks/opscode-pushy-server/recipes/opscode-pushy-server.rb
@@ -36,6 +36,10 @@ link "#{node['pushy']['install_path']}/embedded/service/opscode-pushy-server/log
   to pushy_log_dir
 end
 
+# If we don't set the advertised name, we use the VIP as default.  This might not be routable in
+# some configurations, and eventually we will need to protect against that.
+node.default['pushy']['opscode-pushy-server']['server_name_advertised'] ||=  node['pushy']['opscode-pushy-server']['vip']
+
 template "#{node['pushy']['install_path']}/embedded/service/opscode-pushy-server/bin/opscode-pushy-server" do
   source "opscode-pushy-server.erb"
   owner "root"

--- a/files/pushy-server-cookbooks/opscode-pushy-server/templates/default/opscode-pushy-server.config.erb
+++ b/files/pushy-server-cookbooks/opscode-pushy-server/templates/default/opscode-pushy-server.config.erb
@@ -80,7 +80,7 @@
            {metrics_module, folsom_metrics}
           ]},
  {pushy, [
-          {server_name, "<%= node['pushy']['opscode-pushy-server']['vip'] %>" },
+          {server_name, "<%= @server_name_advertised %>" },
           {heartbeat_interval, <%= @heartbeat_interval %> },
           {zeromq_listen_address, "<%= @zeromq_listen_address %>" },
           {server_heartbeat_port, <%= @server_heartbeat_port %> },


### PR DESCRIPTION
Add attribute to allow client visible server name to be set separately from the VIP

https://github.com/chef/omnibus-pushy/issues/69

A push client needs to be able to reach the backend VIP to connect to the push jobs server. This
causes trouble in some network topologies. This is unlike any other part of chef server; everything
else goes through nginx on the front end nodes, but zeromq can't do that.

The server can advertise to clients a different name to use, but this was defaulted to the backend
VIP, which may not be routable from the clients. Making this independently settable lets the user
choose a name or ip that is routable, perhaps via a firewall rule.

This adds an default attribute ['pushy']['opscode-pushy-server']['server_name_for_client'] to allow
access to the server feature.