### PR TITLE
Prepare for el7 build

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -11,7 +11,7 @@ driver:
 
 provisioner:
   name: chef_zero
-  require_chef_omnibus: 11.10.4
+  require_chef_omnibus: 12.1.0
 
 platforms:
   - name: ubuntu-12.04
@@ -19,7 +19,11 @@ platforms:
   - name: ubuntu-10.04
     run_list: apt::default
   - name: centos-5.10
+    run_list: yum-epel::default
   - name: centos-6.5
+    run_list: yum-epel::default
+  - name: centos-7.0
+    run_list: yum-epel::default
 
 suites:
   - name: default

--- a/Berksfile
+++ b/Berksfile
@@ -7,3 +7,5 @@ cookbook 'omnibus', '~> 2.5'
 
 # Uncomment to use the latest version of the Omnibus cookbook from GitHub
 # cookbook 'omnibus', github: 'opscode-cookbooks/omnibus'
+
+cookbook 'yum-epel', '~> 0.6'

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -1,6 +1,7 @@
 DEPENDENCIES
   apt (~> 2.0)
   omnibus (~> 2.5)
+  yum-epel (~> 0.6)
 
 GRAPH
   7-zip (1.0.2)
@@ -11,7 +12,7 @@ GRAPH
   chef_handler (1.1.6)
   homebrew (1.12.0)
     build-essential (>= 2.1.2)
-  omnibus (2.5.2)
+  omnibus (2.5.5)
     7-zip (~> 1.0)
     build-essential (~> 2.0)
     chef-sugar (~> 2.0)
@@ -22,3 +23,6 @@ GRAPH
     chef_handler (>= 0.0.0)
   wix (1.1.0)
     windows (>= 1.2.2)
+  yum (3.5.3)
+  yum-epel (0.6.0)
+    yum (~> 3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ GIT
 
 GIT
   remote: git://github.com/opscode/omnibus.git
-  revision: 51ca37c7b299b64ee9eba3fd5458293cf85adea0
+  revision: 50f19078a3de46bc93b15bd5549264cd1841adb1
   specs:
     omnibus (4.0.0)
       chef-sugar (~> 2.2)

--- a/config/projects/opscode-push-jobs-server.rb
+++ b/config/projects/opscode-push-jobs-server.rb
@@ -15,7 +15,7 @@
 #
 
 name       "opscode-push-jobs-server"
-maintainer "Chef Software, Inc."
+maintainer "Chef Software, Inc. <maintainers@chef.io>"
 homepage   "http://www.getchef.com"
 
 install_dir    "/opt/opscode-push-jobs-server"


### PR DESCRIPTION
This PR prepares the push server project to run on el7 CI nodes when they are deployed: 

- [x] el7 build/tests verified with test-kitchen.
- [x]  el5/el6 build passes in CI:  http://wilson.ci.chef.co/view/Push%20Jobs%20Server/job/opscode-push-jobs-server-trigger-ad_hoc/69/downstreambuildview/

cc @chef/ociv @manderson26 