### PR TITLE
Update to OpenSSL 1.0.1m

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/opscode/omnibus-software.git
-  revision: 2e26be554787803214ba9525b6b4214b5c7b6d43
+  revision: e5912a9c375c280219c4c5e9d4d8ed92547f2cc4
   specs:
     omnibus-software (4.0.0)
 

--- a/config/projects/opscode-push-jobs-server.rb
+++ b/config/projects/opscode-push-jobs-server.rb
@@ -27,6 +27,7 @@ build_iteration 1
 override :cacerts, version: '2014.08.20'
 override :berkshelf, version: "2.0.18"
 override :erlang, version: "R16B03-1"
+override :'omnibus-ctl', version: '0.3.1'
 
 # creates required build directories
 dependency "preparation"


### PR DESCRIPTION
This version of OpenSSL fixes the following security issues:

CVE-2015-0286
CVE-2015-0287
CVE-2015-0289
CVE-2015-0293
CVE-2015-0209
CVE-2015-0288

/cc @adamedx @manderson26 @chef/ociv 

CI test run: http://wilson.ci.chef.co/job/opscode-push-jobs-server-trigger-ad_hoc/70/downstreambuildview/