### PR TITLE
Decrease the pushy heartbeat interval

### DIFF
--- a/files/pushy-server-cookbooks/opscode-pushy-server/attributes/default.rb
+++ b/files/pushy-server-cookbooks/opscode-pushy-server/attributes/default.rb
@@ -40,7 +40,7 @@ default['pushy']['opscode-pushy-server']['db_pool_size'] = '20'
 default['pushy']['opscode-pushy-server']['ibrowse_max_sessions'] = 256
 default['pushy']['opscode-pushy-server']['ibrowse_max_pipeline_size'] = 1
 
-default['pushy']['opscode-pushy-server']['heartbeat_interval'] = '1000'
+default['pushy']['opscode-pushy-server']['heartbeat_interval'] = '10000'
 
 default['pushy']['opscode-pushy-server']['zeromq_listen_address'] = 'tcp://*'
 default['pushy']['opscode-pushy-server']['zmq_io_processes'] = '1'


### PR DESCRIPTION
Lowering the rate of heartbeats reduces the amount that get buffered.

Related to these PRs:
https://github.com/chef/oc-pushy-pedant/pull/54
https://github.com/chef/opscode-pushy-client/pull/86

Knife:
chef/knife-push#45