### PR TITLE
[JEX-169] Update enterprise cookbook version for systemd support on ubuntu

### DIFF
--- a/files/pushy-server-cookbooks/opscode-pushy-server/Berksfile
+++ b/files/pushy-server-cookbooks/opscode-pushy-server/Berksfile
@@ -1,5 +1,5 @@
 
 metadata
 
-cookbook 'enterprise', :git => 'git@github.com:opscode-cookbooks/enterprise-chef-common.git', :tag => '0.5.1'
+cookbook 'enterprise', :git => 'git@github.com:opscode-cookbooks/enterprise-chef-common.git', :tag => '0.10.1'
 cookbook 'runit', '= 1.6.0'

--- a/files/pushy-server-cookbooks/opscode-pushy-server/attributes/default.rb
+++ b/files/pushy-server-cookbooks/opscode-pushy-server/attributes/default.rb
@@ -18,6 +18,7 @@
 ###
 # High level options
 ###
+default['enterprise']['name'] = 'private_chef'
 default['pushy']['install_path'] = "/opt/opscode-push-jobs-server"
 
 default['pushy']['bootstrap']['enable'] = true


### PR DESCRIPTION
Green pipeline run in my dev jenkins cluster:  http://10.194.10.88/job/opscode-push-jobs-server-trigger-ad_hoc/2/downstreambuildview/